### PR TITLE
If you're given a list of hosts, take the car, not cadr

### DIFF
--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -45,7 +45,7 @@ See `auth-source-search' for details on SPEC."
   (cl-assert (or (null type) (eq type (oref backend type)))
              t "Invalid password-store search: %s %s")
   (when (listp host)
-    (setq host (cadr host)))
+    (setq host (car host)))
   (let ((entry (auth-pass--find-match host user)))
     (when entry
       (list (list


### PR DESCRIPTION
Gnus, at least, provides a single-item list for the host.  To get the
first item one should use `car`; `cadr`, on the other hand, attempts to
get the first item of the tail of the list, a.k.a, the second item.

This is still just a stopgap solution to #1---according to the documentation of
`auth-source-search`, it should actually be iterating over that, and perhaps
other entries, not just taking the first.