### PR TITLE
README: fix some markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use [melpa](http://melpa.milkbox.net).
 
 ## Setup
 
-Add the folowwing to your =init.el= file:
+Add the folowwing to your `init.el` file:
 
     (require 'auth-password-store)
     (auth-pass-enable)


### PR DESCRIPTION
markdown doesn't actually supports orgs verbatim indicators (=text=), so
use its code formatting via backticks.