### PR TITLE
Find non-exactly matching hosts

### DIFF
--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -167,14 +167,7 @@ found, return nil."
        (when (= (length components) 3)
          (let ((top-level-host (mapconcat 'identity (cdr components) ".")))
            (auth-source-do-debug "auth-password-store: searching for '%s' in entry names" top-level-host)
-           (auth-pass--find-by-entry-name top-level-host user)))))
-   (progn
-     (auth-source-do-debug "auth-password-store: no entry name matched '%s', looking inside entries" host)
-     (seq-find (lambda (entry)
-                 (and
-                  (string= host (auth-pass-get "url" entry))
-                  (auth-pass--user-match-p entry user)))
-               (password-store-list)))))
+           (auth-pass--find-by-entry-name top-level-host user)))))))
 
 (provide 'auth-password-store)
 ;;; auth-password-store.el ends here

--- a/test/auth-password-store-tests.el
+++ b/test/auth-password-store-tests.el
@@ -97,6 +97,16 @@ test code without touching the filesystem."
   (should (equal (auth-pass--find-match "https://SomeUser@foo" nil)
                  "SomeUser@foo")))
 
+(auth-pass-deftest find-match-matching-at-entry-name-without-subdomain ()
+                   '(("bar.com" ("url" . "value")))
+  (should (equal (auth-pass--find-match "foo.bar.com" nil)
+                 "bar.com")))
+
+(auth-pass-deftest find-match-matching-at-entry-name-without-subdomain-prefer-full ()
+                   '(("bar.com" ("url" . "value")) ("foo.bar.com" ("url" . "value")))
+  (should (equal (auth-pass--find-match "foo.bar.com" nil)
+                 "foo.bar.com")))
+
 (ert-deftest hostname ()
   (should (equal (auth-pass--hostname "https://foo.bar") "foo.bar"))
   (should (equal (auth-pass--hostname "http://foo.bar") "foo.bar"))


### PR DESCRIPTION
Searching for "foo.bar.com" will now match "bar.com".

/cc @divansantana