### PR TITLE
Enable finding entries by "host/username".

### DIFF
--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -188,25 +188,28 @@ often."
     (auth-pass--do-debug "entry '%s' is not valid" entry)
     nil))
 
-(defun auth-pass--find-all-by-entry-name (name)
-  "Search the store for all entries matching NAME.
-Only return valid entries as of `auth-pass--entry-valid-p'.'"
+(defun auth-pass--find-all-by-entry-name (entryname user)
+  "Search the store for all entries either matching ENTRYNAME/USER or ENTRYNAME.
+Only return valid entries as of `auth-pass--entry-valid-p'."
   (seq-filter (lambda (entry)
                 (and
-                 (string-equal
-                  name
-                  (auth-pass--remove-directory-name entry))
+                 (or
+                  (let ((components-host-user
+                         (member entryname (split-string entry "/"))))
+                    (and (= (length components-host-user) 2)
+                         (string-equal user (cadr components-host-user))))
+                  (string-equal entryname (auth-pass--remove-directory-name entry)))
                  (auth-pass--entry-valid-p entry)))
               (password-store-list)))
 
-(defun auth-pass--find-one-by-entry-name (name user)
-  "Search the store for an entry matching NAME.
+(defun auth-pass--find-one-by-entry-name (entryname user)
+  "Search the store for an entry matching ENTRYNAME.
 If USER is non nil, give precedence to entries containing a user field
 matching USER."
   (auth-pass--do-debug "searching for '%s' in entry names (user: %s)"
-                       name
+                       entryname
                        user)
-  (let ((matching-entries (auth-pass--find-all-by-entry-name name)))
+  (let ((matching-entries (auth-pass--find-all-by-entry-name entryname user)))
     (pcase (length matching-entries)
       (0 (auth-pass--do-debug "no match found")
          nil)

--- a/test/auth-password-store-tests.el
+++ b/test/auth-password-store-tests.el
@@ -209,14 +209,18 @@ This macro overrides `auth-pass-parse-entry', `password-store-list', and
 
 (ert-deftest only-return-entries-that-can-be-open ()
   (cl-letf (((symbol-function 'password-store-list)
-             (lambda () '("foo.site.com" "bar.site.com")))
+             (lambda () '("foo.site.com" "bar.site.com"
+                          "mail/baz.site.com/scott")))
             ((symbol-function 'auth-pass--entry-valid-p)
-             ;; only foo.site.com is valid
-             (lambda (entry) (string-equal entry "foo.site.com"))))
-    (should (equal (auth-pass--find-all-by-entry-name "foo.site.com")
+             ;; only foo.site.com and mail/baz.site.com/scott are valid
+             (lambda (entry) (member entry '("foo.site.com"
+                                             "mail/baz.site.com/scott")))))
+    (should (equal (auth-pass--find-all-by-entry-name "foo.site.com" "someuser")
                    '("foo.site.com")))
-    (should (equal (auth-pass--find-all-by-entry-name "bar.site.com")
-                   '()))))
+    (should (equal (auth-pass--find-all-by-entry-name "bar.site.com" "someuser")
+                   '()))
+    (should (equal (auth-pass--find-all-by-entry-name "baz.site.com" "scott")
+                   '("mail/baz.site.com/scott")))))
 
 (ert-deftest entry-is-not-valid-when-unreadable ()
   (cl-letf (((symbol-function 'password-store--run-show)


### PR DESCRIPTION
This is an attempt to add another convention when find entries, and tends to be slightly more compatible with the [Firefox addon](https://github.com/nwallace/passff#readme). For instance, I have entries like
```
mail/smtp.domain1.com/userx
mail/smtp.domain1.com/usery@some.domain.com
mail/mail.domain2.com/userz
```
where some host can have multiple users defined. I think this scheme helps finding entries. Because otherwise you have to `pass grep` to find usernames.
Cheers