### PR TITLE
Updated Makefile to refer to .el file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ USER_ELPA_D  = $(EMACS_D)/elpa
 
 SRCS         = $(filter-out %-pkg.el, $(wildcard *.el))
 TESTS        = $(wildcard test/*.el)
-TAR          = $(DIST)/auth-password-store-$(VERSION).tar
+TAR          = $(DIST)/auth-password-store-$(VERSION).el
 
 
 .PHONY: all deps check install uninstall reinstall clean-all clean


### PR DESCRIPTION
Cask only generates tar archives for multi-file packages.

See the Cask [docs](http://cask.readthedocs.io/en/latest/guide/usage.html?highlight=tar#cask-package) for more info.