### PR TITLE
Try to extract user from host

### DIFF
--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -145,6 +145,10 @@ CONTENTS is the contents of a password-store formatted file."
      (hostname hostname)
      (t host))))
 
+(defun auth-pass--user (host)
+  "Extract user from HOST or return nil."
+  (url-user (url-generic-parse-url host)))
+
 (defun auth-pass--remove-directory-name (name)
   "Remove directories from NAME.
 E.g., if NAME is \"foo/bar\", return \"bar\"."
@@ -217,7 +221,7 @@ matching USER."
 If many matches are found, return the first one.  If no match is
 found, return nil."
   (or
-   (if (url-user (url-generic-parse-url host))
+   (if (auth-pass--user host)
        ;; if HOST contains a user (e.g., "user@host.com"), <HOST>
        (auth-pass--find-one-by-entry-name (auth-pass--hostname-with-user host) user)
      ;; otherwise, if USER is provided, search for <USER>@<HOST>
@@ -225,6 +229,8 @@ found, return nil."
        (auth-pass--find-one-by-entry-name (concat user "@" (auth-pass--hostname host)) user)))
    ;; if that didn't work, search for HOST without it's user component if any
    (auth-pass--find-one-by-entry-name (auth-pass--hostname host) user)
+   ;; if that didn't work, search for HOST with user extracted from it
+   (auth-pass--find-one-by-entry-name (auth-pass--hostname host) (auth-pass--user host))
    ;; if that didn't work, remove subdomain: foo.bar.com -> bar.com
    (let ((components (split-string host "\\.")))
      (when (= (length components) 3)

--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -130,11 +130,6 @@ CONTENTS is the contents of a password-store formatted file."
                                     (mapconcat #'identity (cdr pair) ":")))))
                         (cdr lines)))))
 
-(defun auth-pass--user-match-p (entry user)
-  "Return true iff ENTRY match USER."
-  (or (null user)
-      (string= user (auth-pass-get "user" entry))))
-
 (defun auth-pass--hostname (host)
   "Extract hostname from HOST."
   (let ((url (url-generic-parse-url host)))

--- a/test/auth-password-store-tests.el
+++ b/test/auth-password-store-tests.el
@@ -134,6 +134,11 @@ test code without touching the file system."
   (should (equal (auth-pass--find-match "foo.bar.com" nil)
                  nil)))
 
+(auth-pass-deftest find-match-matching-extracting-user-from-host ()
+                   '(("foo.com/bar"))
+  (should (equal (auth-pass--find-match "https://bar@foo.com" nil)
+                 "foo.com/bar")))
+
 (auth-pass-deftest search-with-user-first ()
                    '(("foo") ("user@foo"))
   (should (equal (auth-pass--find-match "foo" "user")


### PR DESCRIPTION
Thank you for creating this great package!

I wanted to integrate it with magit to have my password automatically filled but I have encountered the following problem. Magit asks auth source for a password in the following way (https://github.com/magit/magit/blob/master/lisp/magit-process.el#L675):

```elisp
(auth-source-search :max 1 :host key :require '(:host))
```

where `host` is for example `https://login@github.com` and user is missing. So I thought we could extract the user from the host itself. What do you think of such solution? I have added a corresponding test case.