### PR TITLE
Clarify that auth-source-pass is modified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the following to your `init.el` file:
 
 ## Installing on Emacs >= 26
 
-This library has been included in Emacs 26 (still unreleased) under
+A modified version of this library has been included in Emacs 26 (still unreleased) under
 the name `auth-source-pass`. To start using it, just add the following
 to your `init.el` file:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ to your `init.el` file:
     (require 'auth-source-pass)
     (auth-source-pass-enable)
 
+Note that issues for `auth-source-pass` should still be reported on
+[auth-password-store's issue tracker](https://github.com/DamienCassou/auth-password-store/issues).
+Please make sure to specify which library you use.
+
 ## Organization
 
 Auth-password-store follows the first approach suggested by the


### PR DESCRIPTION
Maybe it'd also be good to add a note about reporting issues? That is, whether to report here and clarify whether one is using `auth-source-pass` or `auth-password-store`, or to just report a bug to emacs if using `auth-source-pass`...