### PR TITLE
Fail gracefully when dealing with special auth-source-search inputs.

### DIFF
--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -45,10 +45,18 @@
 See `auth-source-search' for details on SPEC."
   (cl-assert (or (null type) (eq type (oref backend type)))
              t "Invalid password-store search: %s %s")
-  (when (listp host)
+  (when (consp host)
+    (warn "auth-password-store ignores all but first host in spec.")
     ;; Take the first non-nil item of the list of hosts
     (setq host (seq-find #'identity host)))
-  (list (auth-pass--build-result host port user)))
+  (cond ((eq host t)
+         (warn "auth-password-store does not handle host wildcards.")
+         nil)
+        ((null host)
+         ;; Do not build a result, as none will match when HOST is nil
+         nil)
+        (t
+         (list (auth-pass--build-result host port user)))))
 
 (defun auth-pass--build-result (host port user)
   "Build auth-pass entry matching HOST, PORT and USER."

--- a/test/auth-password-store-tests.el
+++ b/test/auth-password-store-tests.el
@@ -78,6 +78,16 @@ test code without touching the file system."
              (auth-pass--debug-log nil))
          ,@body))))
 
+(auth-pass-deftest any-host ()
+                   '(("foo" ("port" . "foo-port") ("host" . "foo-user"))
+                     ("bar"))
+  (should-not (auth-pass-search :host t)))
+
+(auth-pass-deftest undefined-host ()
+                   '(("foo" ("port" . "foo-port") ("host" . "foo-user"))
+                     ("bar"))
+  (should-not (auth-pass-search :host nil)))
+
 (auth-pass-deftest find-match-matching-at-entry-name ()
                    '(("foo"))
   (should (equal (auth-pass--find-match "foo" nil nil)


### PR DESCRIPTION
* auth-password-store.el (auth-pass-search): Warn when passing multiple hosts in
  SPEC. Early return and warn when passing a wildcard as host in SPEC. Early
  return when host is undefined.

Should mitigate the worst effects of #29, allowing `auth-password-store` to be used in e.g. spacemacs without breaking existing workflows. 