### PR TITLE
Silence byte compiler warning

### DIFF
--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -80,8 +80,7 @@ See `auth-source-search' for details on SPEC."
   (auth-source-forget-all-cached))
 
 (defvar auth-pass-backend
-  (auth-source-backend "password-store"
-                       :source "." ;; not used
+  (auth-source-backend :source "." ;; not used
                        :type 'password-store
                        :search-function #'auth-pass-search)
   "Auth-source backend for password-store.")

--- a/auth-password-store.el
+++ b/auth-password-store.el
@@ -80,7 +80,8 @@ See `auth-source-search' for details on SPEC."
   (auth-source-forget-all-cached))
 
 (defvar auth-pass-backend
-  (auth-source-backend :source "." ;; not used
+  (auth-source-backend (when (<= emacs-major-version 25) "password-store")
+                       :source "." ;; not used
                        :type 'password-store
                        :search-function #'auth-pass-search)
   "Auth-source backend for password-store.")


### PR DESCRIPTION
See bug report #54.  The name argument to auth-source-backend has been
made obsolete in Emacs 26.