### PR TITLE
Return nil if no entry found

### DIFF
--- a/auth-source-pass.el
+++ b/auth-source-pass.el
@@ -56,7 +56,8 @@ See `auth-source-search' for details on SPEC."
          ;; Do not build a result, as none will match when HOST is nil
          nil)
         (t
-         (list (auth-source-pass--build-result host port user)))))
+         (when-let ((result (auth-source-pass--build-result host port user)))
+           (list result)))))
 
 (defun auth-source-pass--build-result (host port user)
   "Build auth-source-pass entry matching HOST, PORT and USER."

--- a/test/auth-source-pass-tests.el
+++ b/test/auth-source-pass-tests.el
@@ -83,6 +83,11 @@ This function is intended to be set to `auth-source-debug`."
                                   ("bar"))
     (should-not (auth-source-pass-search :host nil))))
 
+(ert-deftest auth-source-pass-not-found ()
+  (auth-source-pass--with-store '(("foo" ("port" . "foo-port") ("host" . "foo-user"))
+                                  ("bar"))
+    (should-not (auth-source-pass-search :host "baz"))))
+
 
 (ert-deftest auth-source-pass-find-match-matching-at-entry-name ()
   (auth-source-pass--with-store '(("foo"))


### PR DESCRIPTION
If there is no matching entry, auth-source-pass-search should return
nil, not (nil).  This lets auth-source fall back to other backends in
the auth-sources list.