### PR TITLE
Search hostname:port/username

### DIFF
--- a/auth-source-pass.el
+++ b/auth-source-pass.el
@@ -259,6 +259,9 @@ HOSTNAME should not contain any username or port number."
    (and user port (auth-source-pass--find-one-by-entry-name
                    (format "%s@%s%s%s" user hostname auth-source-pass-port-separator port)
                    user))
+   (and user port (auth-source-pass--find-one-by-entry-name
+                   (format "%s%s%s" hostname auth-source-pass-port-separator port)
+                   user))
    (and user (auth-source-pass--find-one-by-entry-name
               (format "%s@%s" user hostname)
               user))

--- a/test/auth-source-pass-tests.el
+++ b/test/auth-source-pass-tests.el
@@ -144,6 +144,17 @@ This function is intended to be set to `auth-source-debug`."
     (should (equal (auth-source-pass--find-match "foo.bar.com" nil nil)
                    nil))))
 
+(ert-deftest auth-source-pass-find-match-matching-host-port-and-subdir-user ()
+  (auth-source-pass--with-store '(("bar.com:443/someone"))
+    (should (equal (auth-source-pass--find-match "bar.com" "someone" "443")
+                   "bar.com:443/someone"))))
+
+(ert-deftest auth-source-pass-find-match-matching-host-port-and-subdir-user-with-custom-separator ()
+  (let ((auth-source-pass-port-separator "#"))
+    (auth-source-pass--with-store '(("bar.com#443/someone"))
+      (should (equal (auth-source-pass--find-match "bar.com" "someone" "443")
+                     "bar.com#443/someone")))))
+
 (ert-deftest auth-source-pass-find-match-matching-extracting-user-from-host ()
   (auth-source-pass--with-store '(("foo.com/bar"))
     (should (equal (auth-source-pass--find-match "https://bar@foo.com" nil nil)


### PR DESCRIPTION
According to README.md auth-source-pass supports entries with username
either prefixed to the hostname with an @ as separator or in a
subdirectory under the hostname.  This was true when there was no port
or service included in the name, but not when there was one.

This commit adds a check for the missed case. I believe that it would
work just as well to replace the nil passed for the user in the call
two lines down, but I wasn't completely sure I wasn't missing
something for why nil was passed in that case so chose the
conservative option of adding the more specific check for the case
when both user and port are supplied.