### PR TITLE
Minimize crypto operations to return an entry

### DIFF
--- a/auth-source-pass.el
+++ b/auth-source-pass.el
@@ -52,17 +52,17 @@
 
 This is useful if your password store contains multiple entries
 that match a search, some of which 'auth-source-pass` doesn't
-parse successfully. Without validation during search the first
-matching entry found will be returned. If it doesn't parse it
+parse successfully.  Without validation during search the first
+matching entry found will be returned.  If it doesn't parse it
 will prevent finding a entry later in the search sequence that
 might have matched.
 
-Validation during search is enabled by default. Consider
+Validation during search is enabled by default.  Consider
 disabling it if your password store is protected by a solution
 that requires a physical action on each cryptographic operation
 such as a PGP smartcard with touch required to complete those
 operations so that retrieving a password typically only requires
-one physical action. If you do so, care in ensuring that entries
+one physical action.  If you do so, care in ensuring that entries
 parse successfully is recommended."
   :type 'boolean)
 


### PR DESCRIPTION
Before this commit, multiple cryptographic operations were required to
return a single result. This doesn't cause any significant issue when
these operations obtain their key material from gpg-agent and no user
interaction beyond possibly an initial passphrase being entered is
required. However, there are some usage scenarios where it becomes
inconvenient. The example that motivated this commit is storing the key
that protects the password store on a PGP smartcard that requires a
physical action like a touch of a sensor to release the result of a
cryptographic operation. In these cases multiple and sometime a
variable number of physical interactions with the smartcard are
require to obtain a single entry.

This commit includes two changes that result in the common cases
requiring only a single physical interaction with the smartcard to
retrieve an entry:

1. `auth-source-pass-get' is split into two pieces, a backend called
   `auth-source-pass--get-attr' that returns the value of a key from
   already parsed entry data and which is then used by the original
   function.  `auth-source-pass--build-result' is then modified to
   parse the entry once and use `auth-source-pass-get-attr'.

2. A new defcustom, `auth-source-pass-validate-during-search' is
   introduced to allow the user to disable the validation of an entry
   during the search to locate applicable entries. This prevents
   cryptographic operations from being required during the search
   process. It does have a downside however in that it changes the
   behavior of the search and could cause users that are finding
   entries successfully to start having errors if they have multiple
   applicable entries in their password store, some of which don't
   parse successfully. For this reason the custom is set to retain the
   current behavior for default.

I've been testing a version with these changes applied and it has been
working well for me.