### PR TITLE
Prefer PASSWORD_STORE_DIR over ~/.password-store

### DIFF
--- a/auth-source-pass.el
+++ b/auth-source-pass.el
@@ -45,7 +45,7 @@
   :group 'auth-source
   :version "27.1")
 
-(defcustom auth-source-pass-filename "~/.password-store"
+(defcustom auth-source-pass-filename (or (getenv "PASSWORD_STORE_DIR") "~/.password-store")
   "Filename of the password-store folder."
   :type 'directory
   :version "27.1")


### PR DESCRIPTION
Fixes https://github.com/DamienCassou/auth-password-store/issues/97.